### PR TITLE
Fixed AsyncEffect.java clear local variables

### DIFF
--- a/src/main/java/com/olyno/skent/util/skript/AsyncEffect.java
+++ b/src/main/java/com/olyno/skent/util/skript/AsyncEffect.java
@@ -37,6 +37,8 @@ public abstract class AsyncEffect extends EffectSection implements Runnable {
     protected void execute(Event e) {
         this.event = e;
         localVars = Variables.removeLocals(e);
+        if (localVars != null)
+            Variables.setLocalVariables(e, localVars);
         Thread effect = new Thread(this);
         effect.setName(this.toString());
         effect.start();
@@ -44,13 +46,11 @@ public abstract class AsyncEffect extends EffectSection implements Runnable {
 
     @Override
     public void run() {
-        if (localVars != null) {
+        if (localVars != null)
             Variables.setLocalVariables(this.event, localVars);
-        }
         this.executeAsync(this.event);
-        if (this.needExecuteCode) {
+        if (this.needExecuteCode)
             this.runSection(this.event);
-        }
         Variables.removeLocals(this.event);
     }
     

--- a/src/main/java/com/olyno/skent/util/skript/AsyncEffect.java
+++ b/src/main/java/com/olyno/skent/util/skript/AsyncEffect.java
@@ -37,8 +37,9 @@ public abstract class AsyncEffect extends EffectSection implements Runnable {
     protected void execute(Event e) {
         this.event = e;
         localVars = Variables.removeLocals(e);
-        if (localVars != null)
+        if (localVars != null) {
             Variables.setLocalVariables(e, localVars);
+        }
         Thread effect = new Thread(this);
         effect.setName(this.toString());
         effect.start();
@@ -46,11 +47,13 @@ public abstract class AsyncEffect extends EffectSection implements Runnable {
 
     @Override
     public void run() {
-        if (localVars != null)
+        if (localVars != null) {
             Variables.setLocalVariables(this.event, localVars);
+        }
         this.executeAsync(this.event);
-        if (this.needExecuteCode)
+        if (this.needExecuteCode) {
             this.runSection(this.event);
+        }
         Variables.removeLocals(this.event);
     }
     

--- a/src/main/java/com/olyno/skent/util/skript/AsyncEffect.java
+++ b/src/main/java/com/olyno/skent/util/skript/AsyncEffect.java
@@ -54,7 +54,6 @@ public abstract class AsyncEffect extends EffectSection implements Runnable {
         if (this.needExecuteCode) {
             this.runSection(this.event);
         }
-        Variables.removeLocals(this.event);
     }
     
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: Skent
 description: Manage files with Skript.
 author: Olyno
-version: 3.0.0
+version: 3.0.1
 main: com.olyno.skent.Skent
 depend:
   - Skript


### PR DESCRIPTION
Hi!
As said in the title, this small PR fixes the clear of local vars into an async effect.

**Example code used:**
```applescript
command skent:
	trigger:
		set {_filepath} to "plugins/example/hello.txt" 
		send "%{_filepath}%"
		create file path "%{_filepath}%"
		send "%{_filepath}%"
```

Where `{_filepath}` were `<none>` after the file creation.